### PR TITLE
Windows8.1 SwapChainPanel Support, C# P/Invoke Support, Memory Leak Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ debug.txt
 *.rej
 *.nupkg
 
+Generated Files

--- a/include/EGL/egl.h
+++ b/include/EGL/egl.h
@@ -249,6 +249,7 @@ typedef void *EGLClientBuffer;
 EGLAPI EGLint EGLAPIENTRY eglGetError(void);
 
 EGLAPI EGLDisplay EGLAPIENTRY eglGetDisplay(EGLNativeDisplayType display_id);
+EGLAPI EGLDisplay EGLAPIENTRY eglGetDisplay_c(EGLNativeDisplayCType display_id);
 EGLAPI EGLBoolean EGLAPIENTRY eglInitialize(EGLDisplay dpy, EGLint *major, EGLint *minor);
 EGLAPI EGLBoolean EGLAPIENTRY eglTerminate(EGLDisplay dpy);
 
@@ -265,6 +266,8 @@ EGLAPI EGLBoolean EGLAPIENTRY eglGetConfigAttrib(EGLDisplay dpy, EGLConfig confi
 EGLAPI EGLSurface EGLAPIENTRY eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config,
 				  EGLNativeWindowType win,
 				  const EGLint *attrib_list);
+EGLAPI EGLSurface EGLAPIENTRY eglCreateWindowSurface_c(EGLDisplay dpy, EGLConfig config,
+	EGLNativeWindowCType win, const EGLint * attrib_list);
 EGLAPI EGLSurface EGLAPIENTRY eglCreatePbufferSurface(EGLDisplay dpy, EGLConfig config,
 				   const EGLint *attrib_list);
 EGLAPI EGLSurface EGLAPIENTRY eglCreatePixmapSurface(EGLDisplay dpy, EGLConfig config,

--- a/include/EGL/eglplatform.h
+++ b/include/EGL/eglplatform.h
@@ -89,6 +89,9 @@ typedef Microsoft::WRL::ComPtr<IUnknown> EGLNativeWindowType;
 typedef EGLNativeWindowType EGLNativeDisplayType;
 typedef HBITMAP EGLNativePixmapType;
 
+typedef IUnknown * EGLNativeWindowCType;
+typedef EGLNativeWindowType EGLNativeDisplayCType;
+
 #endif
 
 #elif defined(_WIN32) || defined(_WIN64)

--- a/src/common/winrtangle.cpp
+++ b/src/common/winrtangle.cpp
@@ -122,6 +122,8 @@ private:
     ID3D11RenderTargetView* m_renderTarget;
 };
 
+extern "C" {
+
 HRESULT __stdcall CreateWinPhone8XamlWindow(IWinPhone8XamlD3DWindow ** result)
 {
     ASSERT(result);
@@ -136,6 +138,8 @@ HRESULT __stdcall CreateWinPhone8XamlWindow(IWinPhone8XamlD3DWindow ** result)
 
     *result = iWindow.Detach();
     return S_OK;
+}
+
 }
 
 class WinrtEglWindow : public RuntimeClass<RuntimeClassFlags<ClassicCom>, IWinrtEglWindow>
@@ -240,6 +244,8 @@ private:
     ID3D11Device* m_device;
 };
 
+extern "C" {
+
 HRESULT __stdcall CreateWinrtEglWindow(IUnknown* windowInterface, ANGLE_D3D_FEATURE_LEVEL featureLevel, IWinrtEglWindow ** result)
 {
     ASSERT(result);
@@ -256,4 +262,4 @@ HRESULT __stdcall CreateWinrtEglWindow(IUnknown* windowInterface, ANGLE_D3D_FEAT
     return S_OK;
 }
 
-
+}

--- a/src/common/winrtangle.h
+++ b/src/common/winrtangle.h
@@ -41,9 +41,16 @@ struct __declspec(uuid("6B70903A-0D55-45BA-A10E-CA2D428E4867")) IWinPhone8XamlD3
     virtual void __stdcall Update(ID3D11Device1* device, ID3D11DeviceContext1* context, ID3D11RenderTargetView* renderTarget) = 0;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 HRESULT __stdcall CreateWinrtEglWindow(IUnknown* windowInterface, ANGLE_D3D_FEATURE_LEVEL featureLevel, IWinrtEglWindow ** result);
 HRESULT __stdcall CreateWinPhone8XamlWindow(IWinPhone8XamlD3DWindow ** result);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif   // WINRT_ANGLE_H_
 

--- a/src/common/winrtutils.cpp
+++ b/src/common/winrtutils.cpp
@@ -81,6 +81,15 @@ bool isSwapChainBackgroundPanel(ComPtr<IUnknown> window)
 #endif // #if defined(ANGLE_PLATFORM_WP8)
 }
 
+bool isSwapChainPanel(Microsoft::WRL::ComPtr<IUnknown> window){
+#if defined(ANGLE_PLATFORM_WP8)
+	return FALSE;
+#else
+	ComPtr<ISwapChainPanelNative> panelNative;
+	return S_OK == (window.As(&panelNative));
+#endif // #if defined(ANGLE_PLATFORM_WP8)
+}
+
 
 ComPtr<ICoreWindow> getCurrentWindowForThread()
 {

--- a/src/common/winrtutils.h
+++ b/src/common/winrtutils.h
@@ -25,6 +25,7 @@ ABI::Windows::Graphics::Display::DisplayOrientations GetDisplayOrientation();
 float convertDipsToPixels(float dips);
 
 bool isSwapChainBackgroundPanel(Microsoft::WRL::ComPtr<IUnknown> window);
+bool isSwapChainPanel(Microsoft::WRL::ComPtr<IUnknown> window);
 
 HRESULT getWindowDimensions(Microsoft::WRL::ComPtr<ABI::Windows::UI::Core::ICoreWindow> window, int& width, int& height);
 

--- a/src/libEGL/libEGL.cpp
+++ b/src/libEGL/libEGL.cpp
@@ -303,7 +303,6 @@ EGLSurface __stdcall eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config, EG
 {
     EVENT("(EGLDisplay dpy = 0x%0.8p, EGLConfig config = 0x%0.8p, EGLNativeWindowType win = 0x%0.8p, "
           "const EGLint *attrib_list = 0x%0.8p)", dpy, config, win, attrib_list);
-
     try
     {
         egl::Display *display = static_cast<egl::Display*>(dpy);
@@ -335,6 +334,7 @@ EGLSurface __stdcall eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config, EG
 EGLSurface __stdcall eglCreateWindowSurface_c(EGLDisplay dpy, EGLConfig config,
 	EGLNativeWindowCType win,
 	const EGLint *attrib_list){
+
 	return eglCreateWindowSurface(dpy, config, EGLNativeWindowType(win), attrib_list);
 }
 

--- a/src/libEGL/libEGL.cpp
+++ b/src/libEGL/libEGL.cpp
@@ -109,6 +109,11 @@ EGLDisplay __stdcall eglGetDisplay(EGLNativeDisplayType display_id)
     }
 }
 
+EGLDisplay __stdcall eglGetDisplay_c(EGLNativeDisplayCType display_id)
+{
+	return eglGetDisplay(EGLNativeDisplayType(display_id));
+}
+
 EGLBoolean __stdcall eglInitialize(EGLDisplay dpy, EGLint *major, EGLint *minor)
 {
     EVENT("(EGLDisplay dpy = 0x%0.8p, EGLint *major = 0x%0.8p, EGLint *minor = 0x%0.8p)",
@@ -325,6 +330,12 @@ EGLSurface __stdcall eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config, EG
     {
         return egl::error(EGL_BAD_ALLOC, EGL_NO_SURFACE);
     }
+}
+
+EGLSurface __stdcall eglCreateWindowSurface_c(EGLDisplay dpy, EGLConfig config,
+	EGLNativeWindowCType win,
+	const EGLint *attrib_list){
+	return eglCreateWindowSurface(dpy, config, EGLNativeWindowType(win), attrib_list);
 }
 
 EGLSurface __stdcall eglCreatePbufferSurface(EGLDisplay dpy, EGLConfig config, const EGLint *attrib_list)

--- a/src/libEGL/libEGL_winrt.def
+++ b/src/libEGL/libEGL_winrt.def
@@ -9,6 +9,7 @@ EXPORTS
 	eglCreatePbufferSurface         @10
 	eglCreatePixmapSurface          @11
 	eglCreateWindowSurface          @9
+	eglCreateWindowSurface_c		@36
 	eglDestroyContext               @24
 	eglDestroySurface               @12
 	eglGetConfigAttrib              @8
@@ -17,6 +18,7 @@ EXPORTS
 	eglGetCurrentDisplay            @28
 	eglGetCurrentSurface            @27
 	eglGetDisplay                   @2
+	eglGetDisplay_c					@35
 	eglGetError                     @1
 	eglGetProcAddress               @34
 	eglInitialize                   @3

--- a/src/libGLESv2/renderer/SwapChain11.cpp
+++ b/src/libGLESv2/renderer/SwapChain11.cpp
@@ -599,7 +599,9 @@ EGLint SwapChain11::reset(int backbufferWidth, int backbufferHeight, EGLint swap
         if(SUCCEEDED(result))
         {
             ComPtr<IUnknown> iWindow = iWinRTWindow->GetWindowInterface();
-            bool isPanel = winrt::isSwapChainBackgroundPanel(iWindow.Get());
+			bool isBgPanel = winrt::isSwapChainBackgroundPanel(iWindow);
+			bool isPanel = winrt::isSwapChainPanel(iWindow);
+			bool isAnyPanel = isBgPanel || isPanel;
             IDXGIFactory2 *factory = mRenderer->getDxgiFactory();
             DXGI_SWAP_CHAIN_DESC1 swapChainDesc = {0};
             swapChainDesc.Width = backbufferWidth;
@@ -611,8 +613,8 @@ EGLint SwapChain11::reset(int backbufferWidth, int backbufferHeight, EGLint swap
             swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
             swapChainDesc.BufferCount = 2;
             swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL; //must be used for winrt
-            swapChainDesc.Scaling = isPanel ? DXGI_SCALING_STRETCH : DXGI_SCALING_NONE;
-            if (isPanel)
+            swapChainDesc.Scaling = isAnyPanel ? DXGI_SCALING_STRETCH : DXGI_SCALING_NONE;
+            if (isBgPanel)
             {
                 ComPtr<ISwapChainBackgroundPanelNative> panelNative;
                 ComPtr<IUnknown> iWindow = iWinRTWindow->GetWindowInterface();
@@ -626,6 +628,19 @@ EGLint SwapChain11::reset(int backbufferWidth, int backbufferHeight, EGLint swap
                     }
                 }
             }
+			else if (isPanel){
+				ComPtr<ISwapChainPanelNative> panelNative;
+				ComPtr<IUnknown> iWindow = iWinRTWindow->GetWindowInterface();
+				result = iWindow.As(&panelNative);
+				if SUCCEEDED(result)
+				{
+					result = factory->CreateSwapChainForComposition(device, &swapChainDesc, nullptr, &mSwapChain);
+					if SUCCEEDED(result)
+					{
+						panelNative->SetSwapChain(mSwapChain);
+					}
+				}
+			}
             else
             {
                 result = factory->CreateSwapChainForCoreWindow(device, iWindow.Get(), &swapChainDesc, nullptr, &mSwapChain);


### PR DESCRIPTION
Hello, stammen san.
Your ANGLE winrt supporting fork is very nice.
I got a lot of help for porting my iOS/Android OpenGL application to Windows8.1.
But a little troubles are there.
I solved them and introduce details in below.
# No SwapChainPanel support

In Windows8.1, Using SwapChainPanel is better than SwapChainBackgroundPanel.
I added support of it.
# It can't be called all functions from C# Managed Layer because of ComPtr class

I use this library for porting iOS/Android OpenGL Application.
I write Application, EAGL(something seems to be EGL for Apple platform) by ObjectiveC and OpenGL by C.
I write Application, EGL, OpenGL by java.
So I want to write application by C#  and call EGL, OpenGL by C# too.
I made P/Invoke Static functions class in C# and call through corresponding C native function provided by this library.
This approach is same to Java. Java OpenGL is simple JNI glue codes to native.
But, only 2 function can't be call.
They are eglGetDisplay and eglCreateWindowSurface.
Because their arguments contains EGLNativeWindowType. 
this is ComPtr<T> in this WinRT support fork.
it is C++ class so it can not link to C# by P/Invoke interface.
So I added simple C version of them, eglGetDisplay_c, eglCreateWindowSurface_c.
but I think that this solution is bad.
EGL function should not be modified/added if there are any other way.
I think best approach is changing EGLNativeWindowType ComPtr<IUnkown> to IUnknown*.
but it has many modification points and potential to happen memory management problem.
And I'm not familiar with COM programming, DirectX programming, My project time is finite.
So I gave up to do best and do bad out of need.

And I change some function to extern "C".
# Fix memory leak

I found that Xaml Page class never be destructed if it contains SwapChainPanel setup by ANGLE.
I try to fix it and finally i found bug in below.
IWinrtEglWindow::GetWindowInterface() returns ComObject that is called AddRef().
return value directly assign (using operator=) to ComPtr<T>.
So it occurs memory leak by Over Retain.
I changed this to call ComPtr<T>.Attach() method.
