### PR TITLE
Image stabilization cannot be disabled

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicNativeWindow.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicNativeWindow.cpp
@@ -144,7 +144,7 @@ bool HolographicNativeWindow::initialize(EGLNativeWindowType holographicSpace, I
         ComPtr<IInspectable> enableAutomaticDepthBasedImageStabilizationPropertyInspectable;
         if (SUCCEEDED(result) && hasEglAutomaticDepthBasedImageStabilizationProperty)
         {
-            result = spPropertyMap->Lookup(HStringReference(EGLAutomaticStereoRenderingProperty).Get(), &enableAutomaticDepthBasedImageStabilizationPropertyInspectable);
+            result = spPropertyMap->Lookup(HStringReference(EGLAutomaticDepthBasedImageStabilizationProperty).Get(), &enableAutomaticDepthBasedImageStabilizationPropertyInspectable);
         }
 
         ComPtr<IPropertyValue> enableAutomaticDepthBasedImageStabilizationProperty;


### PR DESCRIPTION
Fix error when applying the image stabilization switch value - the value for auto-stereo is read instead.