### PR TITLE
Update holographic rendering parameters for all shaders

### DIFF
--- a/src/libANGLE/Context.cpp
+++ b/src/libANGLE/Context.cpp
@@ -783,6 +783,7 @@ void Context::bindPixelUnpackBuffer(GLuint buffer)
 void Context::useProgram(GLuint program)
 {
     mState.setProgram(getProgram(program));
+    mCurrentSurface->onProgramChanged();
 }
 
 void Context::bindTransformFeedback(GLuint transformFeedback)

--- a/src/libANGLE/Surface.h
+++ b/src/libANGLE/Surface.h
@@ -86,6 +86,8 @@ class Surface final : public gl::FramebufferAttachmentObject
 
     bool directComposition() const { return mDirectComposition; }
 
+    void onProgramChanged() { mImplementation->onProgramChanged(); }
+
   private:
     virtual ~Surface();
     rx::FramebufferAttachmentObjectImpl *getAttachmentImpl() const override { return mImplementation; }

--- a/src/libANGLE/renderer/SurfaceImpl.h
+++ b/src/libANGLE/renderer/SurfaceImpl.h
@@ -49,6 +49,7 @@ class SurfaceImpl : public FramebufferAttachmentObjectImpl
 
     virtual EGLint isPostSubBufferSupported() const = 0;
     virtual EGLint getSwapBehavior() const = 0;
+    virtual void onProgramChanged() = 0;
 };
 
 }

--- a/src/libANGLE/renderer/d3d/SurfaceD3D.cpp
+++ b/src/libANGLE/renderer/d3d/SurfaceD3D.cpp
@@ -319,7 +319,6 @@ void SurfaceD3D::onProgramChanged()
     }
     else
     {
-        OutputDebugStringA("\n!!! Update params on program change !!!\n");
         if (mSwapChain == nullptr)
         {
             // On Windows Holographic, we will have a null swap chain for a while

--- a/src/libANGLE/renderer/d3d/SurfaceD3D.cpp
+++ b/src/libANGLE/renderer/d3d/SurfaceD3D.cpp
@@ -307,6 +307,37 @@ egl::Error SurfaceD3D::resetSwapChain(int backbufferWidth, int backbufferHeight)
     return egl::Error(EGL_SUCCESS);
 }
 
+void SurfaceD3D::onProgramChanged()
+{
+#ifdef ANGLE_ENABLE_WINDOWS_HOLOGRAPHIC
+    EGLint status = EGL_SUCCESS;
+    // Holographic swap chains will have a back buffer width and height of 0
+    // temporarily while waiting for the first holographic camera.
+    if (!mNativeWindow.isHolographic())
+    {
+        return;
+    }
+    else
+    {
+        OutputDebugStringA("\n!!! Update params on program change !!!\n");
+        if (mSwapChain == nullptr)
+        {
+            // On Windows Holographic, we will have a null swap chain for a while
+            // while waiting for the first holographic camera to arrive.
+            // So, mSwapChain being null is expected.
+            return;
+        }
+
+        // Update all holographic cameras.
+        EGLint status = EGL_SUCCESS;
+        for each (auto const& swapChain in mHolographicSwapChains)
+        {
+            swapChain->updateHolographicRenderingParameters();
+        }
+    }
+#endif
+}
+
 egl::Error SurfaceD3D::swapRect(EGLint x, EGLint y, EGLint width, EGLint height)
 {
     if (!mSwapChain)

--- a/src/libANGLE/renderer/d3d/SurfaceD3D.h
+++ b/src/libANGLE/renderer/d3d/SurfaceD3D.h
@@ -76,6 +76,8 @@ class SurfaceD3D : public SurfaceImpl
     gl::Error getAttachmentRenderTarget(const gl::FramebufferAttachment::Target &target,
                                         FramebufferAttachmentRenderTarget **rtOut) override;
 
+    void onProgramChanged() override;
+
   private:
     SurfaceD3D(RendererD3D *renderer,
                egl::Display *display,

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicNativeWindow.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicNativeWindow.cpp
@@ -144,7 +144,7 @@ bool HolographicNativeWindow::initialize(EGLNativeWindowType holographicSpace, I
         ComPtr<IInspectable> enableAutomaticDepthBasedImageStabilizationPropertyInspectable;
         if (SUCCEEDED(result) && hasEglAutomaticDepthBasedImageStabilizationProperty)
         {
-            result = spPropertyMap->Lookup(HStringReference(EGLAutomaticStereoRenderingProperty).Get(), &enableAutomaticDepthBasedImageStabilizationPropertyInspectable);
+            result = spPropertyMap->Lookup(HStringReference(EGLAutomaticDepthBasedImageStabilizationProperty).Get(), &enableAutomaticDepthBasedImageStabilizationPropertyInspectable);
         }
 
         ComPtr<IPropertyValue> enableAutomaticDepthBasedImageStabilizationProperty;

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.cpp
@@ -397,8 +397,7 @@ void HolographicSwapChain11::ComputeMidViewMatrix(
     }
 }
 
-EGLint HolographicSwapChain11::updateHolographicRenderingParameters(
-    ComPtr<ABI::Windows::Graphics::Holographic::IHolographicCameraRenderingParameters>& spCameraRenderingParameters)
+EGLint HolographicSwapChain11::updateHolographicRenderingParameters()
 {
     TRACE_EVENT0("gpu.angle", "HolographicSwapChain11::updateHolographicRenderingParameters");
 
@@ -415,6 +414,14 @@ EGLint HolographicSwapChain11::updateHolographicRenderingParameters(
     }
 
     HRESULT result = S_OK;
+
+    ComPtr<ABI::Windows::Graphics::Holographic::IHolographicCameraRenderingParameters> spCameraRenderingParameters;
+    if (SUCCEEDED(result))
+    {
+        UINT32 id = mHolographicCameraId;
+        // This will take care of back buffer, depth buffer, viewport, coordinate system, and view/projection matrix(es).
+        result = mHolographicNativeWindow->GetHolographicRenderingParameters(id, spCameraRenderingParameters.GetAddressOf());
+    }
 
     // Update back buffer resources.
     {
@@ -787,16 +794,11 @@ EGLint HolographicSwapChain11::reset(int backbufferWidth, int backbufferHeight, 
     
     HRESULT hr = S_OK;
 
-    ComPtr<ABI::Windows::Graphics::Holographic::IHolographicCameraRenderingParameters> spParameters;
-    if (SUCCEEDED(hr))
-    {
-        // This will take care of back buffer, depth buffer, viewport, coordinate system, and view/projection matrix(es).
-        hr = mHolographicNativeWindow->GetHolographicRenderingParameters(id, spParameters.GetAddressOf());
-    }
+    
 
     if (SUCCEEDED(hr))
     {
-        EGLint result = updateHolographicRenderingParameters(spParameters);
+        EGLint result = updateHolographicRenderingParameters();
             
         if (result != EGL_SUCCESS)
         {

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.cpp
@@ -761,58 +761,30 @@ DXGI_FORMAT HolographicSwapChain11::getSwapChainNativeFormat() const
 EGLint HolographicSwapChain11::reset(int backbufferWidth, int backbufferHeight, EGLint swapInterval)
 {
     // Windows Holographic apps use APIs to access the back buffer.
-    UINT32 id = mHolographicCameraId;
 
-    {
-        HRESULT hr = S_OK;
-
-        ComPtr<ABI::Windows::Graphics::Holographic::IHolographicCameraPose> spPose;
-        if (SUCCEEDED(hr))
-        {
-            hr = mHolographicNativeWindow->GetHolographicCameraPose(id, spPose.GetAddressOf());
-        }
-
-        if (SUCCEEDED(hr))
-        {
-            spPose->get_NearPlaneDistance(&mNearPlaneDistance);
-            spPose->get_FarPlaneDistance(&mFarPlaneDistance);
-
-            // Ensure the values we set previously made it through.
-            assert(mNearPlaneDistance ==  0.1f);
-            assert(mFarPlaneDistance  == 20.0f);
-
-            ABI::Windows::Foundation::Rect viewportRect;
-            spPose->get_Viewport(&viewportRect);
-            mViewport = CD3D11_VIEWPORT(
-                viewportRect.X,
-                viewportRect.Y,
-                viewportRect.Width,
-                viewportRect.Height
-            );
-        }
-    }
-    
-    HRESULT hr = S_OK;
-
-    
+    ComPtr<ABI::Windows::Graphics::Holographic::IHolographicCameraPose> spPose;
+    HRESULT hr = mHolographicNativeWindow->GetHolographicCameraPose(mHolographicCameraId, spPose.GetAddressOf());
 
     if (SUCCEEDED(hr))
     {
-        EGLint result = updateHolographicRenderingParameters();
-            
-        if (result != EGL_SUCCESS)
-        {
-            return result;
-        }
-        else
-        {
-            return EGL_SUCCESS;
-        }
+        spPose->get_NearPlaneDistance(&mNearPlaneDistance);
+        spPose->get_FarPlaneDistance(&mFarPlaneDistance);
+
+        // Ensure the values we set previously made it through.
+        assert(mNearPlaneDistance == 0.1f);
+        assert(mFarPlaneDistance == 20.0f);
+
+        ABI::Windows::Foundation::Rect viewportRect;
+        spPose->get_Viewport(&viewportRect);
+        mViewport = CD3D11_VIEWPORT(
+            viewportRect.X,
+            viewportRect.Y,
+            viewportRect.Width,
+            viewportRect.Height
+        );
     }
-    else
-    {
-        return EGL_BAD_DISPLAY;
-    }
+
+    return EGL_SUCCESS;
 }
 
 // parameters should be validated/clamped by caller

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.cpp
@@ -762,29 +762,31 @@ EGLint HolographicSwapChain11::reset(int backbufferWidth, int backbufferHeight, 
 {
     // Windows Holographic apps use APIs to access the back buffer.
 
-    ComPtr<ABI::Windows::Graphics::Holographic::IHolographicCameraPose> spPose;
-    HRESULT hr = mHolographicNativeWindow->GetHolographicCameraPose(mHolographicCameraId, spPose.GetAddressOf());
-
-    if (SUCCEEDED(hr))
     {
-        spPose->get_NearPlaneDistance(&mNearPlaneDistance);
-        spPose->get_FarPlaneDistance(&mFarPlaneDistance);
+        ComPtr<ABI::Windows::Graphics::Holographic::IHolographicCameraPose> spPose;
+        HRESULT hr = mHolographicNativeWindow->GetHolographicCameraPose(mHolographicCameraId, spPose.GetAddressOf());
 
-        // Ensure the values we set previously made it through.
-        assert(mNearPlaneDistance == 0.1f);
-        assert(mFarPlaneDistance == 20.0f);
+        if (SUCCEEDED(hr))
+        {
+            spPose->get_NearPlaneDistance(&mNearPlaneDistance);
+            spPose->get_FarPlaneDistance(&mFarPlaneDistance);
 
-        ABI::Windows::Foundation::Rect viewportRect;
-        spPose->get_Viewport(&viewportRect);
-        mViewport = CD3D11_VIEWPORT(
-            viewportRect.X,
-            viewportRect.Y,
-            viewportRect.Width,
-            viewportRect.Height
-        );
+            // Ensure the values we set previously made it through.
+            assert(mNearPlaneDistance == 0.1f);
+            assert(mFarPlaneDistance == 20.0f);
+
+            ABI::Windows::Foundation::Rect viewportRect;
+            spPose->get_Viewport(&viewportRect);
+            mViewport = CD3D11_VIEWPORT(
+                viewportRect.X,
+                viewportRect.Y,
+                viewportRect.Width,
+                viewportRect.Height
+            );
+        }
     }
 
-    return EGL_SUCCESS;
+    return updateHolographicRenderingParameters();
 }
 
 // parameters should be validated/clamped by caller

--- a/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.h
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/HolographicSwapChain11.h
@@ -48,7 +48,7 @@ class HolographicSwapChain11 : public SwapChainD3D
     virtual ~HolographicSwapChain11();
 
             EGLint  resize(EGLint backbufferWidth, EGLint backbufferHeight);
-            EGLint  updateHolographicRenderingParameters(ComPtr<ABI::Windows::Graphics::Holographic::IHolographicCameraRenderingParameters>& cameraRenderingParameters);
+            EGLint  updateHolographicRenderingParameters();
     virtual EGLint  reset(EGLint backbufferWidth, EGLint backbufferHeight, EGLint swapInterval);
     virtual EGLint  swapRect(EGLint x, EGLint y, EGLint width, EGLint height);
             EGLint  swapRect(ABI::Windows::Graphics::Holographic::IHolographicFrame* pHolographicFrame);


### PR DESCRIPTION
Currently, holographic rendering parameters are updated on swapChain::reset. Consequently, holographic parameters are only updated for the last used shader. If multiple shaders are used sequentially, they will not have their holographic parameters updated.

This change introduces a notification from glContext when a program is used. When in holographic mode, the holographic rendering parameters will be updated for the then active shaders.