### PR TITLE
DisplayProperties have been deprecated, we're supposed to use DisplayInformation

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/winrt/CoreWindowNativeWindow.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/CoreWindowNativeWindow.cpp
@@ -209,19 +209,19 @@ HRESULT GetCoreWindowSizeInPixels(const ComPtr<ABI::Windows::UI::Core::ICoreWind
 
 static float GetLogicalDpi()
 {
-    ComPtr<ABI::Windows::Graphics::Display::IDisplayPropertiesStatics> displayProperties;
+	ComPtr<ABI::Windows::Graphics::Display::IDisplayInformation> displayInformation;
 
-    if (SUCCEEDED(GetActivationFactory(HStringReference(RuntimeClass_Windows_Graphics_Display_DisplayProperties).Get(), displayProperties.GetAddressOf())))
-    {
-        float dpi = 96.0f;
-        if (SUCCEEDED(displayProperties->get_LogicalDpi(&dpi)))
-        {
-            return dpi;
-        }
-    }
+	if (SUCCEEDED(GetActivationFactory(HStringReference(RuntimeClass_Windows_Graphics_Display_DisplayInformation).Get(), displayInformation.GetAddressOf())))
+	{
+		float dpi = 96.0f;
+		if (SUCCEEDED(displayInformation->get_LogicalDpi(&dpi)))
+		{
+			return dpi;
+		}
+	}
 
-    // Return 96 dpi as a default if display properties cannot be obtained.
-    return 96.0f;
+	// Return 96 dpi as a default if display properties cannot be obtained.
+	return 96.0f;
 }
 
 float ConvertDipsToPixels(float dips)


### PR DESCRIPTION
Is this sufficient?