### PR TITLE
Fixed a crash when a swapchainpanel resize occured before it has been…

### DIFF
--- a/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainPanelNativeWindow.cpp
+++ b/src/libANGLE/renderer/d3d/d3d11/winrt/SwapChainPanelNativeWindow.cpp
@@ -325,6 +325,11 @@ HRESULT SwapChainPanelNativeWindow::createSwapChain(ID3D11Device *device,
 
 HRESULT SwapChainPanelNativeWindow::scaleSwapChain(const Size &windowSize, const RECT &clientRect)
 {
+    if(!mSwapChain)
+    {
+        return S_OK;
+    }
+    
     Size renderScale = {windowSize.Width / (float)clientRect.right,
                         windowSize.Height / (float)clientRect.bottom};
     // Setup a scale matrix for the swap chain


### PR DESCRIPTION
… properly initialized. Could happen e.g. when starting up an app on changed DPI settings or when min size has been changed.